### PR TITLE
for unit test when use jetty9

### DIFF
--- a/code/tpushserver/trunk/src/test/java/com/tongbupan/test/websocket/tunit/WebSocketServerMaxConnsTest_SingleThread.java
+++ b/code/tpushserver/trunk/src/test/java/com/tongbupan/test/websocket/tunit/WebSocketServerMaxConnsTest_SingleThread.java
@@ -210,6 +210,8 @@ public class WebSocketServerMaxConnsTest_SingleThread {
 		// 1.init websocket client factory
 		WebSocketClientFactory factory = new WebSocketClientFactory();
 		factory.setBufferSize(WEBSOCKET_CLIENT_FACTORY_BUFFSIZE);
+		factory.getSslContextFactory().setTrustAll(true);
+		factory.getSslContextFactory().addExcludeProtocols("SSLv2Hello","SSLv3");
 		try {
 			factory.start();
 		} catch (Exception e) {


### PR DESCRIPTION
when use jetty9, the default ssl version is sslv3, can't compatible with test ws client
